### PR TITLE
Config option to process aggregates before minifying

### DIFF
--- a/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java
+++ b/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java
@@ -108,9 +108,9 @@ public class YuiCompressorMojo extends MojoSupport {
 
     /**
      * aggregate files before minify
-     * @parameter expression="${maven.yuicompressor.aggregateFirst}" default-value="false"
+     * @parameter expression="${maven.yuicompressor.preProcessAggregates}" default-value="false"
      */
-    private boolean aggregateFirst;
+    private boolean preProcessAggregates;
 
     private long inSizeTotal_;
     private long outSizeTotal_;
@@ -126,7 +126,7 @@ public class YuiCompressorMojo extends MojoSupport {
             suffix = "";
         }
 
-        if(aggregateFirst) aggregate();
+        if(preProcessAggregates) aggregate();
     }
 
     @Override
@@ -135,7 +135,7 @@ public class YuiCompressorMojo extends MojoSupport {
             getLog().info(String.format("total input (%db) -> output (%db)[%d%%]", inSizeTotal_, outSizeTotal_, ((outSizeTotal_ * 100)/inSizeTotal_)));
         }
 
-        if(!aggregateFirst) aggregate();
+        if(!preProcessAggregates) aggregate();
     }
 
     private void aggregate() throws Exception {


### PR DESCRIPTION
When building a library to use externally, it makes more sense to aggregate first, then minify. So you result in an aggregated readable file, and one minified one.

Added preProcessAggregates as a configuration option. Default is false.

```
<configuration>
    <preProcessAggregates>true</preProcessAggregates>
    ...
</configuration>
```
