### PR TITLE
Quick fix to ensure temporary files are not left around after plugin execution

### DIFF
--- a/src/main/java/net_alchim31_maven_yuicompressor/JSLintChecker.java
+++ b/src/main/java/net_alchim31_maven_yuicompressor/JSLintChecker.java
@@ -16,6 +16,7 @@ class JSLintChecker {
         InputStream in = null;
         try {
             File jslint = File.createTempFile("jslint", ".js");
+            jslint.deleteOnExit();
             in = getClass().getResourceAsStream("/jslint.js");
             out = new FileOutputStream(jslint);
             IOUtil.copy(in, out);


### PR DESCRIPTION
Hello David,

I have been using your Maven plugin for a while and it is working very well. Thanks for the good job. I discovered a small issue while using it in that for each execution, a temporary file is created, but never cleaned. Of course those files are created in a temporary folder, but if it is not purged, then a lot of files will stay inside. That's what is happening on my CI infrastructure for example.

Thus, I made this small one-line change to ensure that temporary files are deleted once the JVM is shut down.

Would you mind merging this fix for the next version of your plugin?

Best regards,
Reynald
