### PR TITLE
Remove the assumption of project.basedir that effects multi module maven projects

### DIFF
--- a/src/main/java/net_alchim31_maven_yuicompressor/MojoSupport.java
+++ b/src/main/java/net_alchim31_maven_yuicompressor/MojoSupport.java
@@ -188,7 +188,7 @@ public abstract class MojoSupport extends AbstractMojo {
         scanner.scan();
         for(String name :scanner.getIncludedFiles() ) {
             SourceFile src = new SourceFile(srcRoot, destRoot, name, destAsSource);
-            jsErrorReporter_.setDefaultFileName("..." + src.toFile().getAbsolutePath().substring(project.getBasedir().getAbsolutePath().length()));
+            jsErrorReporter_.setDefaultFileName("..." + src.toFile().getAbsolutePath().substring(src.toFile().getAbsolutePath().lastIndexOf('/')+1));
             processFile(src);
         }
     }


### PR DESCRIPTION
When src dir is in different folder than project.basedir, this causes an error because the plugin assumes the src is in the same dir as project.basedir.
