### PR TITLE
Permit automatic exclusions aggregation strategy

### DIFF
--- a/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java
+++ b/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java
@@ -6,6 +6,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -155,9 +158,12 @@ public class YuiCompressorMojo extends MojoSupport {
 
     private void aggregate() throws Exception {
         if (aggregations != null) {
+            Set<File> previouslyIncludedFiles = new HashSet<File>();
             for(Aggregation aggregation : aggregations) {
                 getLog().info("generate aggregation : " + aggregation.output);
-                aggregation.run();
+                Collection<File> aggregatedFiles = aggregation.run(previouslyIncludedFiles);
+                previouslyIncludedFiles.addAll(aggregatedFiles);
+
                 File gzipped = gzipIfRequested(aggregation.output);
                 if (statistics) {
                     if (gzipped != null) {

--- a/src/test/java/net_alchim31_maven_yuicompressor/AggregationTestCase.java
+++ b/src/test/java/net_alchim31_maven_yuicompressor/AggregationTestCase.java
@@ -1,6 +1,8 @@
 package net_alchim31_maven_yuicompressor;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
 
 import junit.framework.TestCase;
 
@@ -26,17 +28,17 @@ public class AggregationTestCase extends TestCase {
         target.output = new File(dir_, "output.js");
 
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertFalse(target.output.exists());
 
         target.includes = new String[]{};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertFalse(target.output.exists());
 
         target.includes = new String[]{"**/*.js"};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertFalse(target.output.exists());
     }
 
@@ -49,7 +51,7 @@ public class AggregationTestCase extends TestCase {
         target.includes = new String[]{f1.getName()};
 
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1), FileUtils.fileRead(target.output));
     }
@@ -66,14 +68,14 @@ public class AggregationTestCase extends TestCase {
 
         target.includes = new String[]{f1.getName(), f2.getName()};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
 
         target.output.delete();
         target.includes = new String[]{"*.js"};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
     }
@@ -90,14 +92,14 @@ public class AggregationTestCase extends TestCase {
 
         target.includes = new String[]{f1.getName(), f1.getName(), f2.getName()};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
 
         target.output.delete();
         target.includes = new String[]{f1.getName(), "*.js"};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
     }
@@ -114,7 +116,7 @@ public class AggregationTestCase extends TestCase {
 
         target.includes = new String[]{f2.getName(), f1.getName()};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f2) + FileUtils.fileRead(f1), FileUtils.fileRead(target.output));
     }
@@ -132,7 +134,7 @@ public class AggregationTestCase extends TestCase {
         target.includes = new String[]{f1.getName(), f2.getName()};
 
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1) + "\n" + FileUtils.fileRead(f2) + "\n", FileUtils.fileRead(target.output));
     }
@@ -149,7 +151,7 @@ public class AggregationTestCase extends TestCase {
 
         target.includes = new String[]{f1.getAbsolutePath(), f2.getName()};
         assertFalse(target.output.exists());
-        target.run();
+        target.run(null);
         assertTrue(target.output.exists());
         assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
     }
@@ -167,11 +169,39 @@ public class AggregationTestCase extends TestCase {
 
             target.includes = new String[]{f1.getAbsolutePath(), f2.getName()};
             assertFalse(target.output.exists());
-            target.run();
+            target.run(null);
             assertTrue(target.output.exists());
             assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
         } finally {
             f1.delete();
         }
+    }
+
+    public void testAutoExcludeWildcards() throws Exception {
+        File f1 = new File(dir_, "01.js");
+        FileUtils.fileWrite(f1.getAbsolutePath(), "1");
+
+        File f2 = new File(dir_, "02.js");
+        FileUtils.fileWrite(f2.getAbsolutePath(), "22\n22");
+
+        Aggregation target = new Aggregation();
+        target.autoExcludeWildcards = true;
+        target.output = new File(dir_, "output.js");
+
+        Collection<File> previouslyIncluded = new HashSet<File>();
+        previouslyIncluded.add(f1);
+
+        target.includes = new String[]{f1.getName(), f2.getName()};
+        assertFalse(target.output.exists());
+        target.run(previouslyIncluded);
+        assertTrue(target.output.exists());
+        assertEquals(FileUtils.fileRead(f1) + FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
+
+        target.output.delete();
+        target.includes = new String[]{"*.js"};
+        assertFalse(target.output.exists());
+        target.run(previouslyIncluded);
+        assertTrue(target.output.exists());
+        assertEquals(FileUtils.fileRead(f2), FileUtils.fileRead(target.output));
     }
 }


### PR DESCRIPTION
It would be great to have an aggregation strategy that would omit files which were included in other aggregations.

Example (assume files A.css through H.css):

``` xml
<aggregations>
    <aggregation>
        <includes>
            <include>**/A.css</include>
            <include>**/B.css</include>
            <include>**/C.css</include>
        </includes>
        <output>${project.build.outputDirectory}/A-C.css</output>
    </aggregation>
    <aggregation>
        <includes>
            <include>**/F.css</include>
            <include>**/G.css</include>
        </includes>
        <output>${project.build.outputDirectory}/F-G.css</output>
    </aggregation>
    <aggregation>
        <includes>
            <include>**/*.css</include>
        </includes>
        <excludes>
            <exclude>**/H.css</exclude>
        </excludes>
        <autoExclude>true</autoExclude>
        <output>${project.build.outputDirectory}/D-E.css</output>
    </aggregation>
    <aggregation>
        <includes>
            <include>**/*.css</include>
        </includes>
        <autoExclude>true</autoExclude>
        <output>${project.build.outputDirectory}/H.css</output>
    </aggregation>
</aggregations>
```

This would be a great convenience for the case where multiple special aggregations are needed (like A-C and F-G).
