### PR TITLE
Statistic logging for gzip compression is misleading

### DIFF
--- a/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java
+++ b/src/main/java/net_alchim31_maven_yuicompressor/YuiCompressorMojo.java
@@ -237,11 +237,11 @@ public class YuiCompressorMojo extends MojoSupport {
             } else {
                 fileStatistics = String.format("%s (%db) -> %s (%db)[%d%%]", inFile.getName(), inFile.length(), outFile.getName(), outFile.length(), ratioOfSize(inFile, outFile));
             }
-            getLog().info(fileStatistics);
 
             if (gzipped != null) {
-                getLog().info(String.format("%s (%db) -> %s (%db)[%d%%]", inFile.getName(), inFile.length(), gzipped.getName(), gzipped.length(), ratioOfSize(inFile, gzipped)));
+                fileStatistics = fileStatistics + String.format(" -> %s (%db)[%d%%]", gzipped.getName(), gzipped.length(), ratioOfSize(inFile, gzipped));
             }
+            getLog().info(fileStatistics);
         }
     }
 


### PR DESCRIPTION
The current statistic output for gzip compression makes it appear as though the original file is being gzipped, where as it is actually the minified (or otherwise copied) version.

```
[INFO] ie.css (1376b) -> ie-min.css (624b)[45%]
[INFO] ie.css (1376b) -> ie-min.css.gz (362b)[26%]
[INFO] ie6.css (0b) -> ie6-min.css (0b)[100%]
[INFO] ie6.css (0b) -> ie6-min.css.gz (20b)[2000%]
[INFO] ie7.css (468b) -> ie7-min.css (263b)[56%]
[INFO] ie7.css (468b) -> ie7-min.css.gz (149b)[31%]
[INFO] ie9.css (177b) -> ie9-min.css (45b)[25%]
[INFO] ie9.css (177b) -> ie9-min.css.gz (46b)[25%]
```

More correct would be to use the outFile's name and filesize (the gzipped percentage is a ratio of the minified size):

```
[INFO] ie.css (1376b) -> ie-min.css (624b)[45%]
[INFO] ie-min.css (624b) -> ie-min.css.gz (362b)[58%]
[INFO] ie6.css (0b) -> ie6-min.css (0b)[100%]
[INFO] ie6-min.css (0b) -> ie6-min.css.gz (20b)[2000%]
[INFO] ie7.css (468b) -> ie7-min.css (263b)[56%]
[INFO] ie7-min.css (263b) -> ie7-min.css.gz (149b)[57%]
[INFO] ie9.css (177b) -> ie9-min.css (45b)[25%]
[INFO] ie9-min.css (45b) -> ie9-min.css.gz (46b)[102%]
```

This pull request instead condenses these to a single line (the gzipped percentage is a ratio of the original size):

```
[INFO] ie.css (1376b) -> ie-min.css (624b)[45%] -> ie-min.css.gz (362b)[26%]
[INFO] ie6.css (0b) -> ie6-min.css (0b)[100%] -> ie6-min.css.gz (20b)[2000%]
[INFO] ie7.css (468b) -> ie7-min.css (263b)[56%] -> ie7-min.css.gz (149b)[31%]
[INFO] ie9.css (177b) -> ie9-min.css (45b)[25%] -> ie9-min.css.gz (46b)[25%]
```

And when nocompress=true:

```
[INFO] ie.css (1376b) -> ie-min.css (1376b)[100%] -> ie-min.css.gz (588b)[42%]
[INFO] No compression is enabled
[INFO] ie6.css (0b) -> ie6-min.css (0b)[100%] -> ie6-min.css.gz (20b)[2000%]
[INFO] No compression is enabled
[INFO] ie7.css (468b) -> ie7-min.css (468b)[100%] -> ie7-min.css.gz (221b)[47%]
[INFO] No compression is enabled
[INFO] ie9.css (177b) -> ie9-min.css (177b)[100%] -> ie9-min.css.gz (105b)[59%]
```
